### PR TITLE
Fix state_changes to be destroyed when the associated order is destroyed

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -37,7 +37,8 @@ module Spree
 
     alias_attribute :ship_total, :shipment_total
 
-    has_many :state_changes, as: :stateful
+    belongs_to :store, class_name: 'Spree::Store'
+    has_many :state_changes, as: :stateful, dependent: :destroy
     has_many :line_items, -> { order("#{LineItem.table_name}.created_at ASC") }, dependent: :destroy, inverse_of: :order
     has_many :payments, dependent: :destroy
     has_many :return_authorizations, dependent: :destroy, inverse_of: :order
@@ -460,6 +461,7 @@ module Spree
       updater.update_item_count
       adjustments.destroy_all
       shipments.destroy_all
+      state_changes.destroy_all
 
       update_totals
       persist_totals


### PR DESCRIPTION
I want to use the `orders#empty!` for the iPad api. I checked to see what were the latest changes in upstream and they added removing state change records to this. The following is the original quote body

Here is the original issue that was referenced: spree/spree#6370.
