### PR TITLE
Added a new size for paperclip: ipad 65x65

### DIFF
--- a/core/app/models/spree/image.rb
+++ b/core/app/models/spree/image.rb
@@ -3,7 +3,7 @@ module Spree
     validate :no_attachment_errors
 
     has_attached_file :attachment,
-                      styles: { mini: '48x48>', small: '100x100>', product: '240x240>', large: '600x600>' },
+                      styles: { mini: '48x48>', ipad: '65x65>', small: '100x100>', product: '240x240>', large: '600x600>' },
                       default_style: :product,
                       url: '/spree/products/:id/:style/:basename.:extension',
                       path: ':rails_root/public/spree/products/:id/:style/:basename.:extension',


### PR DESCRIPTION
I want to open this up for discussion. We currently have have a small thumbnail size of 100x100. The iPad app uses it 65x65 thumbnails.

What do you guys think? Is it worth optimizing or is returning a 100x100x sufficient?

@kurtfunai @cwise @glongman 
