### PR TITLE
PaperClip upgrade from 4.3.0 to 4.3.1

### DIFF
--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'json', '~> 1.7'
   s.add_dependency 'kaminari', '~> 0.16.1'
   s.add_dependency 'monetize', '~> 1.1'
-  s.add_dependency 'paperclip', '~> 4.3.0'
+  s.add_dependency 'paperclip', '~> 4.3.1'
   s.add_dependency 'paranoia', '~> 2.0'
   s.add_dependency 'rails', '~> 4.1.12'
   s.add_dependency 'ransack', '~> 1.4.1'


### PR DESCRIPTION
This fixes an issue `4.3.0` where it will return `nil` when it's a new instance of a record. 
[paperclip change log](https://github.com/thoughtbot/paperclip/blob/f7ea479afdb4c4892209ff419319e0e6deee77b3/NEWS)
[old version of url method in 4.3.0](https://github.com/thoughtbot/paperclip/blob/v4.3.0/lib/paperclip/attachment.rb#L139)
[new version of url method in 4.3.1](https://github.com/thoughtbot/paperclip/blob/v4.3.1/lib/paperclip/attachment.rb#L139)
