### PR TITLE
Updated create_payment profile from upstream

### DIFF
--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -165,9 +165,14 @@ module Spree
         payment_method.respond_to?(:payment_profiles_supported?) && payment_method.payment_profiles_supported?
       end
 
+      # Update from upstream 3e0b405a
       def create_payment_profile
-        return unless source.respond_to?(:has_payment_profile?) && !source.has_payment_profile? &&
-          state != 'invalid' && state != 'failed'
+        # Don't attempt to create on bad payments.
+        return if %w(invalid failed).include?(state)
+        # Payment profile cannot be created without source
+        return unless source
+        # Imported payments shouldn't create a payment profile.
+        return if source.respond_to?(:imported) && source.imported
 
         payment_method.create_profile(self)
       rescue ActiveMerchant::ConnectionError => e


### PR DESCRIPTION
This change was necessary in order to properly create a payment profile.
The version we were using was outdated and did not factor in how Stripe
works.

A small modification was required in order to function properly:

`source.respond_to?(:imported)`

Our credit cards (in the test case) did not have this method.

Code was taken at around spree/spree:3e0b405a (upstream)
https://github.com/spree/spree/commit/3e0b405a#diff-d985c9327156568e9d480c22cfdac03eR188
but the method itself had gone over many changes prior to that so this
commit is not the only relevant one.
