### PR TITLE
Routes visibility change fix WAS: test - revert immediately if it does not work

### DIFF
--- a/core/lib/spree/core/routes.rb
+++ b/core/lib/spree/core/routes.rb
@@ -39,7 +39,8 @@ module Spree
       end
 
       def eval_block(&block)
-        Spree::Core::Engine.routes.eval_block(block)
+        # HACK
+        Spree::Core::Engine.routes.send :eval_block, block
       end
     end
   end


### PR DESCRIPTION
spree core is trying to call `eval_block` on the core Engine routes.
`eval_block` is now private.

Will check one more thing before proceeding with this test.