### PR TITLE
Responders & controller test support rails42

### DIFF
--- a/core/lib/spree/core/controller_helpers/respond_with.rb
+++ b/core/lib/spree/core/controller_helpers/respond_with.rb
@@ -3,26 +3,19 @@ require 'spree/responder'
 module ActionController
   class Base
     def respond_with(*resources, &block)
-      raise "In order to use respond_with, first you need to declare the formats your " <<
-            "controller responds to in the class level" if self.class.mimes_for_respond_to.empty?
 
-      if collector = retrieve_collector_from_mimes(&block)
-        options = resources.size == 1 ? {} : resources.extract_options!
-
-        if defined_response = collector.response and !Spree::BaseController.spree_responders.keys.include?(self.class.to_s.to_sym)
-          if action = options.delete(:action)
-            render :action => action
-          else
-            defined_response.call
-          end
+      # from Spree core HEAD
+      if Spree::BaseController.spree_responders.keys.include?(self.class.to_s.to_sym)
+        # Checkout AS Array#extract_options! and original respond_with
+        #         # implementation for a better picture of this hack
+        if resources.last.is_a? Hash
+          resources.last.merge! action_name: action_name.to_sym
         else
-          # The action name is needed for processing
-          options.merge!(:action_name => action_name.to_sym)
-          # If responder is not specified then pass in Spree::Responder
-          responder = options.delete(:responder) || self.responder
-          responder.call(self, resources, options)
+          resources.push action_name: action_name.to_sym
         end
       end
+
+      super
     end
   end
 end

--- a/core/lib/spree/testing_support/controller_requests.rb
+++ b/core/lib/spree/testing_support/controller_requests.rb
@@ -73,15 +73,20 @@ module Spree
       private
 
       def process_spree_action(action, parameters = nil, session = nil, flash = nil, method = "GET")
+        @routes = Spree::Core::Engine.routes
         parameters ||= {}
-        process(action, method, parameters.merge!(:use_route => :spree), session, flash)
+        process(action, method, parameters, session, flash)
+      ensure
+        @routes = Rails.application.routes
       end
 
       def process_spree_xhr_action(action, parameters = nil, session = nil, flash = nil, method = :get)
+        @routes = Spree::Core::Engine.routes
         parameters ||= {}
         parameters.reverse_merge!(:format => :json)
-        parameters.merge!(:use_route => :spree)
         xml_http_request(method, action, parameters, session, flash)
+      ensure
+        @routes = Rails.application.routes
       end
     end
   end


### PR DESCRIPTION
- controller test support - set Spree routes when calling helpers like spree_post
  - reset to app routes before method exits.