### PR TITLE
Adjustments - Use explicit Row level deleted when computing taxes

### DIFF
--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -87,7 +87,7 @@ module Spree
       tax_categories = rates.map(&:tax_category)
       relevant_items, non_relevant_items = items.partition { |item| tax_categories.include?(item.tax_category) }
       relevant_items.each do |item|
-        item.adjustments.tax.delete_all
+        item.adjustments.tax.destroy_all
         relevant_rates = rates.select { |rate| rate.tax_category == item.tax_category }
         store_pre_tax_amount(item, relevant_rates)
         relevant_rates.each do |rate|
@@ -96,7 +96,7 @@ module Spree
       end
       non_relevant_items.each do |item|
         if item.adjustments.tax.present?
-          item.adjustments.tax.delete_all
+          item.adjustments.tax.destroy_all
           item.update_column(:pre_tax_amount, nil)
           Spree::ItemAdjustments.new(item).update
         end


### PR DESCRIPTION
Tax computation occurs repeatedly per order, per line item, per step during checkout.
Spree::TaxRate computes new Adjustments after deleting the old ones.

A PR in Solidus pointed out that using `delete_all` can result in generated SQL that
contains polymorphic columns and caused INNODB to take gap locks. Under load this can result
in deadlock.

Using `destroy_all` means only primary key based deletes will occur. No gap locks so deadlocks can be
less likely.

`spree_adjustments` is a high traffic table. Spree::Adjustment has no `after_destroy` or relations that would invoke logic on destroy so this should be safe.

Ref: https://github.com/solidusio/solidus/pull/127