### PR TITLE
Updated json gem to 2.3.

### DIFF
--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'highline', '~> 1.6.18' # Necessary for the install generator
   s.add_dependency 'httparty', '~> 0.14' # For checking alerts.
   s.add_dependency 'i18n', '~> 0.7' # required for rails 4.2
-  s.add_dependency 'json', '~> 1.7'
+  s.add_dependency 'json', '~> 2.3'
   s.add_dependency 'kaminari', '~> 0.17.0'
   s.add_dependency 'monetize', '~> 1.6'
   s.add_dependency 'paperclip', '~> 5.1.0'


### PR DESCRIPTION
Due to security vulnerability, we are required to update the `json` gem to version 2.3.